### PR TITLE
Add MarcasModel basic structure

### DIFF
--- a/app/Models/MarcasModel.php
+++ b/app/Models/MarcasModel.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class MarcasModel extends Model
+{
+    protected $table      = 'marcas';
+    protected $primaryKey = 'marca';
+
+    protected $allowedFields = [
+        'marca',
+        'marca_descrip',
+    ];
+
+    protected $returnType    = 'array';
+    protected $useTimestamps = false;
+
+    protected $validationRules = [
+        'marca'         => 'required|max_length[15]|is_unique[marcas.marca,marca,{marca}]',
+        'marca_descrip' => 'permit_empty|max_length[50]',
+    ];
+
+    protected $validationMessages = [
+        'marca' => [
+            'required'  => 'El campo marca es obligatorio.',
+            'is_unique' => 'La marca ya existe.',
+        ],
+        'marca_descrip' => [
+            'max_length' => 'La descripción debe tener como máximo 50 caracteres.',
+        ],
+    ];
+}


### PR DESCRIPTION
## Summary
- implement `MarcasModel` with namespace, table, and allowed fields
- add validation rules/messages similar to `ProductosModel`

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714d2ee87c8329bec6b5eca29e39d3